### PR TITLE
Move unmodifiable code to module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,59 +1,11 @@
-use std::fmt;
-
 /**
  * WorkerPool and Worker are provided from an external library and cannot be modified
  *
  * WorkerPool is responsible for creating new workers, and keeps track of how many workers are created
  * Workers perform some action and are closed when they are done
  */
-#[derive(Debug, Clone, Default)]
-pub struct WorkerPool {
-    num_workers: u32,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct Worker {
-    closed: bool,
-}
-
-impl WorkerPool {
-    pub fn new() -> WorkerPool {
-        WorkerPool::default()
-    }
-
-    pub fn get_worker(&mut self) -> Worker {
-        self.num_workers += 1;
-        Worker::default()
-    }
-
-    pub fn get_num_workers_created(&self) -> u32 {
-        self.num_workers
-    }
-}
-
-impl Worker {
-    pub fn do_work(&self) -> Result<(), WorkerClosedError> {
-        if self.closed {
-            return Err(WorkerClosedError {});
-        }
-
-        // Do something expensive
-        Ok(())
-    }
-
-    pub fn close(&mut self) {
-        self.closed = true
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct WorkerClosedError;
-
-impl fmt::Display for WorkerClosedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "worker is already closed")
-    }
-}
+mod read_only_lib;
+use read_only_lib::*;
 
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// 

--- a/src/read_only_lib.rs
+++ b/src/read_only_lib.rs
@@ -1,0 +1,51 @@
+
+use std::fmt;
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkerPool {
+    num_workers: u32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Worker {
+    closed: bool,
+}
+
+impl WorkerPool {
+    pub fn new() -> WorkerPool {
+        WorkerPool::default()
+    }
+
+    pub fn get_worker(&mut self) -> Worker {
+        self.num_workers += 1;
+        Worker::default()
+    }
+
+    pub fn get_num_workers_created(&self) -> u32 {
+        self.num_workers
+    }
+}
+
+impl Worker {
+    pub fn do_work(&self) -> Result<(), WorkerClosedError> {
+        if self.closed {
+            return Err(WorkerClosedError {});
+        }
+
+        // Do something expensive
+        Ok(())
+    }
+
+    pub fn close(&mut self) {
+        self.closed = true
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkerClosedError;
+
+impl fmt::Display for WorkerClosedError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "worker is already closed")
+    }
+}


### PR DESCRIPTION
A no-op refactor that better self-documents the "rules" about the part of the codebase that cannot be modified. Just a thought that's been itching the back of my brain.